### PR TITLE
Implement token refresh and wire page APIs

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -19,4 +19,34 @@ axiosInstance.interceptors.request.use((config: any) => {
   return config;
 });
 
+axiosInstance.interceptors.response.use(
+  (response: any) => response,
+  async (error: any) => {
+    const { config, response } = error;
+    const status = response?.status;
+    if (status === 401 && config && !(config as any)._retry) {
+      (config as any)._retry = true;
+      const accessToken = localStorage.getItem('accessToken');
+      const refreshToken = localStorage.getItem('refreshToken');
+      try {
+        const { data } = await axiosInstance.post('/jwt', {
+          accessToken,
+          refreshToken,
+        });
+        const newAccessToken = data?.data?.accessToken || data?.accessToken;
+        if (newAccessToken) {
+          localStorage.setItem('accessToken', newAccessToken);
+          (config.headers as any).accessToken = newAccessToken;
+        }
+        return axiosInstance(config);
+      } catch (refreshError) {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
 export default axiosInstance;

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -7,21 +7,29 @@ import CalendarIcon from "@/assets/dartkcalendar.svg";
 import MyPageIcon from "@/assets/mypage.svg";
 import CalendarImg from "@/assets/calendarImg.svg";
 import GoToAnswer from "@/assets/goToAnswer.svg";
-import { useCreateMemoMutation, useMonthMemosQuery } from "@/api";
+import {
+  useCreateMemoMutation,
+  useMonthMemosQuery,
+  useMyGroupQuery,
+} from "@/api";
 
 const Calendar = () => {
   const navigate = useNavigate();
   const [isModalOpen, setModalOpen] = useState(false);
   const [content, setContent] = useState("");
   const createMemo = useCreateMemoMutation();
-  const { data: memos } = useMonthMemosQuery(1, "2025-06");
+  const { data: group } = useMyGroupQuery();
+  const groupId = group?.data.groupId || 0;
+  const today = new Date().toISOString().slice(0, 10);
+  const month = today.slice(0, 7);
+  const { data: memos } = useMonthMemosQuery(groupId, month);
 
   const GoHome = () => navigate("/home");
   const GoList = () => navigate("/list");
   const GoMyPage = () => navigate("/my-page");
   const ToggleModal = () => setModalOpen(!isModalOpen);
   const GoShowAnswer = () => {
-    createMemo.mutate({ groupId: 1, date: "2025-02-24", content });
+    createMemo.mutate({ groupId, date: today, content });
     navigate("/show-answer");
   };
 

--- a/src/pages/Calendar/style.tsx
+++ b/src/pages/Calendar/style.tsx
@@ -35,7 +35,7 @@ export const Footer = styled.div`
 
 export const Modal = styled.div<ModalProps>`
   position: fixed;
-  bottom: ${({ isOpen }) => (isOpen ? "0" : "-100%")};
+  bottom: ${({ isOpen }: ModalProps) => (isOpen ? "0" : "-100%")};
   left: 0;
   width: 100%;
   height: 350px;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -43,8 +43,19 @@ const Home = () => {
       </S.Header>
       <S.MainContainer>
         <S.MeetTextCotainer>
-          <>시작일</>
-          <S.BlueText>{data?.data.startedAt}</S.BlueText>
+          <>만난지</>
+          <S.BlueText>
+            {data?.data.startedAt
+              ? `${
+                  Math.floor(
+                    (new Date().getTime() -
+                      new Date(data.data.startedAt).getTime()) /
+                      (1000 * 60 * 60 * 24)
+                  ) + 1
+                }`
+              : ""}
+            <span style={{ color: "black" }}>일 째</span>
+          </S.BlueText>
         </S.MeetTextCotainer>
         <S.MyGroupNames>
           {members.map((m: any, idx: number) => (
@@ -56,9 +67,7 @@ const Home = () => {
         </S.MyGroupNames>
         <S.CharacterImg src={SeaOtter1} />
         <S.QuestionContainer onClick={handleGoAnswer}>
-          <S.QuestionTitle>
-            오늘의 질문 #{firstQuestion?.id}
-          </S.QuestionTitle>
+          <S.QuestionTitle>오늘의 질문 #{firstQuestion?.id}</S.QuestionTitle>
           <S.Question>{firstQuestion?.content}</S.Question>
         </S.QuestionContainer>
       </S.MainContainer>

--- a/src/pages/List/index.tsx
+++ b/src/pages/List/index.tsx
@@ -4,11 +4,13 @@ import Note from "@/assets/dartlist.svg";
 import HomeIcon from "@/assets/grayhome.svg";
 import CalendarIcon from "@/assets/calendar.svg";
 import MyPageIcon from "@/assets/mypage.svg";
-import { useGroupQuestionsQuery } from "@/api";
+import { useGroupQuestionsQuery, useMyGroupQuery } from "@/api";
 
 const List = () => {
   const navigate = useNavigate();
-  const { data } = useGroupQuestionsQuery(1);
+  const { data: group } = useMyGroupQuery();
+  const groupId = group?.data.groupId || 0;
+  const { data } = useGroupQuestionsQuery(groupId);
 
   const GoQuestion = () => {
     navigate("/show-answer");

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -2,7 +2,7 @@ import * as S from "./style";
 import ShellIcon from "@/assets/shell.svg";
 import Heart from "@/assets/heart.svg";
 import CopyIcon from "@/assets/copyIcon.svg";
-import Right from "@/assets/right.svg";
+import RightIcon from "@/assets/right.svg";
 import { useNavigate } from "react-router-dom";
 import Note from "@/assets/note.svg";
 import CalendarIcon from "@/assets/calendar.svg";
@@ -57,19 +57,19 @@ const MyPage = () => {
       <S.SelectList>
         <S.Colum>
           <S.Text>초대 코드 입력하기</S.Text>
-          <S.Right src={Right} />
+          <S.Right src={RightIcon} />
         </S.Colum>
         <S.Colum>
           <S.Text>알림</S.Text>
-          <S.Right src={Right} />
+          <S.Right src={RightIcon} />
         </S.Colum>
         <S.Colum>
           <S.Text>공지사항</S.Text>
-          <S.Right src={Right} />
+          <S.Right src={RightIcon} />
         </S.Colum>
         <S.Colum>
           <S.Text>자주 묻는 질문</S.Text>
-          <S.Right src={Right} />
+          <S.Right src={RightIcon} />
         </S.Colum>
         <S.Colum>
           <S.Text>버전</S.Text>
@@ -86,7 +86,11 @@ const MyPage = () => {
         <img src={GrayHome} onClick={GoHome} style={{ cursor: "pointer" }} />
         <img src={CalendarIcon} onClick={GoCal} style={{ cursor: "pointer" }} />
         <img src={Note} onClick={GoList} style={{ cursor: "pointer" }} />
-        <img src={DarkProfile} onClick={GoMyPage} style={{ cursor: "pointer" }} />
+        <img
+          src={DarkProfile}
+          onClick={GoMyPage}
+          style={{ cursor: "pointer" }}
+        />
       </S.Footer>
     </S.Layout>
   );

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -2,7 +2,7 @@ import * as S from "./style";
 import ShellIcon from "@/assets/shell.svg";
 import Heart from "@/assets/heart.svg";
 import CopyIcon from "@/assets/copyIcon.svg";
-import RightIcon from "@/assets/right.svg";
+import Right from "@/assets/right.svg";
 import { useNavigate } from "react-router-dom";
 import Note from "@/assets/note.svg";
 import CalendarIcon from "@/assets/calendar.svg";
@@ -57,19 +57,19 @@ const MyPage = () => {
       <S.SelectList>
         <S.Colum>
           <S.Text>초대 코드 입력하기</S.Text>
-          <S.RightIcon src={RightIcon} />
+          <S.Right src={Right} />
         </S.Colum>
         <S.Colum>
           <S.Text>알림</S.Text>
-          <S.RightIcon src={RightIcon} />
+          <S.Right src={Right} />
         </S.Colum>
         <S.Colum>
           <S.Text>공지사항</S.Text>
-          <S.RightIcon src={RightIcon} />
+          <S.Right src={Right} />
         </S.Colum>
         <S.Colum>
           <S.Text>자주 묻는 질문</S.Text>
-          <S.RightIcon src={RightIcon} />
+          <S.Right src={Right} />
         </S.Colum>
         <S.Colum>
           <S.Text>버전</S.Text>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
   },
   server: {
     host: true,
-    port: 3001,
+    port: 3000,
   },
 });


### PR DESCRIPTION
## Summary
- implement automatic access token refresh in `axios`
- hook up Calendar and List pages to group APIs
- update Calendar modal style prop typing
- rename `RightIcon` references to `Right` in MyPage

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673816b084832a95ed1adf14210bca