### PR TITLE
Replace calendar image with React component

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -84,3 +84,8 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+input:focus,
+textarea:focus {
+  outline: none;
+}

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import 'react-calendar/dist/Calendar.css';
 import * as S from "./style";
 import Note from "@/assets/graynote.svg";
 import HomeIcon from "@/assets/grayhome.svg";
 import CalendarIcon from "@/assets/dartkcalendar.svg";
 import MyPageIcon from "@/assets/mypage.svg";
-import CalendarImg from "@/assets/calendarImg.svg";
 import GoToAnswer from "@/assets/goToAnswer.svg";
 import {
   useCreateMemoMutation,
@@ -17,32 +17,58 @@ const Calendar = () => {
   const navigate = useNavigate();
   const [isModalOpen, setModalOpen] = useState(false);
   const [content, setContent] = useState("");
+  const [selectedDate, setSelectedDate] = useState(new Date());
   const createMemo = useCreateMemoMutation();
   const { data: group } = useMyGroupQuery();
   const groupId = group?.data.groupId || 0;
-  const today = new Date().toISOString().slice(0, 10);
-  const month = today.slice(0, 7);
+  const month = selectedDate.toISOString().slice(0, 7);
   const { data: memos } = useMonthMemosQuery(groupId, month);
 
   const GoHome = () => navigate("/home");
   const GoList = () => navigate("/list");
   const GoMyPage = () => navigate("/my-page");
-  const ToggleModal = () => setModalOpen(!isModalOpen);
+  const openModal = (date: Date) => {
+    setSelectedDate(date);
+    setModalOpen(true);
+  };
   const GoShowAnswer = () => {
-    createMemo.mutate({ groupId, date: today, content });
+    createMemo.mutate({
+      groupId,
+      date: selectedDate.toISOString().slice(0, 10),
+      content,
+    });
     navigate("/show-answer");
   };
 
-  const firstMemo = memos?.data.memos[0];
+  const firstMemo = memos?.data.memos.find(
+    (m: any) => m.date === selectedDate.toISOString().slice(0, 10)
+  );
+
+  useEffect(() => {
+    if (firstMemo?.content) {
+      setContent(firstMemo.content);
+    } else {
+      setContent('');
+    }
+  }, [firstMemo]);
 
   return (
     <S.Layout>
-      <img
-        src={CalendarImg}
-        style={{ margin: "52px", cursor: "pointer" }}
-        onClick={ToggleModal}
+      <S.StyledCalendar
+        onClickDay={(value: Date) => openModal(value)}
+        value={selectedDate}
+        tileClassName={({ date, view }) => {
+          if (view === 'month') {
+            return memos?.data.memos.some(
+              (m: any) => m.date === date.toISOString().slice(0, 10)
+            )
+              ? 'has-memo'
+              : undefined;
+          }
+          return undefined;
+        }}
       />
-      <S.EditImg onClick={ToggleModal} style={{ cursor: "pointer" }} />
+      <S.EditImg onClick={() => openModal(selectedDate)} style={{ cursor: 'pointer' }} />
       <S.Footer>
         <img src={HomeIcon} onClick={GoHome} style={{ cursor: "pointer" }} />
         <img src={CalendarIcon} style={{ cursor: "pointer" }} />
@@ -51,7 +77,13 @@ const Calendar = () => {
       </S.Footer>
       <S.Modal isOpen={isModalOpen}>
         <S.TextContainer>
-          <h3>2월 16일 금요일</h3>
+          <h3>
+            {selectedDate.toLocaleDateString('ko-KR', {
+              month: 'long',
+              day: 'numeric',
+              weekday: 'long',
+            })}
+          </h3>
           <img
             src={GoToAnswer}
             style={{ cursor: "pointer" }}
@@ -60,7 +92,7 @@ const Calendar = () => {
         </S.TextContainer>
         <S.Input
           placeholder="일정 내용을 입력하세요..."
-          value={content || firstMemo?.content || ""}
+          value={content}
           onChange={(e: any) => setContent(e.target.value)}
         />
       </S.Modal>

--- a/src/pages/Calendar/style.tsx
+++ b/src/pages/Calendar/style.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Calendar from "react-calendar";
 import Background from "@/assets/background.png";
 import EditIcon from "@/assets/edit.svg";
 
@@ -21,6 +22,29 @@ export const EditImg = styled.img.attrs({
   src: EditIcon,
 })`
   margin: 80px 0 0 300px;
+`;
+
+export const StyledCalendar = styled(Calendar)`
+  margin: 52px;
+  border: none;
+  background: transparent;
+  font-family: 'Pretendard-Regular';
+
+  .has-memo {
+    position: relative;
+  }
+
+  .has-memo::after {
+    content: '';
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    background: #84C3EE;
+    border-radius: 50%;
+    transform: translateX(-50%);
+  }
 `;
 
 export const Footer = styled.div`
@@ -56,6 +80,7 @@ export const Input = styled.textarea`
   font-size: 16px;
   box-sizing: border-box;
   resize: none;
+  outline: none;
   ::placeholder {
     color: #c2c2c2;
     text-align: left;

--- a/src/pages/ChooseFeel/style.ts
+++ b/src/pages/ChooseFeel/style.ts
@@ -87,4 +87,5 @@ export const Answer = styled.textarea`
   border-radius: 8px;
   border: 1px solid #dfdfdf;
   padding: 12px 16px;
+  outline: none;
 `;


### PR DESCRIPTION
## Summary
- render a calendar using `react-calendar` instead of a static image
- highlight days that have memos and open memo modal on day click
- remove focus outlines from all inputs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a88654c832ab2e8ed72cf2d691a