### PR TITLE
Fix calendar display and memo date

### DIFF
--- a/src/components/CalendarContainer/index.tsx
+++ b/src/components/CalendarContainer/index.tsx
@@ -71,12 +71,12 @@ const CalendarContainer = ({
   return (
     <S.Container>
       <S.Header>
-        <S.Title>
-          {view.year}년 {String(view.month + 1).padStart(2, "0")}월
-        </S.Title>
         <S.IconBtn onClick={() => moveMonth(-1)}>
           <img src={PrevIcon} alt="prev" />
         </S.IconBtn>
+        <S.Title>
+          {view.year}년 {String(view.month + 1).padStart(2, "0")}월
+        </S.Title>
         <S.IconBtn onClick={() => moveMonth(1)}>
           <img src={NextIcon} alt="next" />
         </S.IconBtn>

--- a/src/components/CalendarContainer/index.tsx
+++ b/src/components/CalendarContainer/index.tsx
@@ -71,12 +71,12 @@ const CalendarContainer = ({
   return (
     <S.Container>
       <S.Header>
-        <S.IconBtn onClick={() => moveMonth(-1)}>
-          <img src={PrevIcon} alt="prev" />
-        </S.IconBtn>
         <S.Title>
           {view.year}년 {String(view.month + 1).padStart(2, "0")}월
         </S.Title>
+        <S.IconBtn onClick={() => moveMonth(-1)}>
+          <img src={PrevIcon} alt="prev" />
+        </S.IconBtn>
         <S.IconBtn onClick={() => moveMonth(1)}>
           <img src={NextIcon} alt="next" />
         </S.IconBtn>
@@ -100,7 +100,7 @@ const CalendarContainer = ({
       </S.DaysGrid>
 
       <S.Footer>
-        만난지 <S.Count>{daysCount}</S.Count>일 째
+        만난지 <S.Count>{daysCount}</S.Count> 일 째
       </S.Footer>
     </S.Container>
   );

--- a/src/components/CalendarContainer/style.ts
+++ b/src/components/CalendarContainer/style.ts
@@ -9,7 +9,7 @@ export const Container = styled.main`
 export const Header = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   padding: 16px 0;
 `;
 
@@ -27,7 +27,7 @@ export const IconBtn = styled.button`
 
 export const Title = styled.h2`
   flex: 1;
-  text-align: left;
+  text-align: center;
   font-size: 18px;
   font-weight: bold;
 `;

--- a/src/components/CalendarContainer/style.ts
+++ b/src/components/CalendarContainer/style.ts
@@ -19,15 +19,11 @@ export const IconBtn = styled.button`
   cursor: pointer;
   width: 24px;
   height: 24px;
-  img {
-    width: 100%;
-    height: 100%;
-  }
 `;
 
 export const Title = styled.h2`
   flex: 1;
-  text-align: center;
+  text-align: start;
   font-size: 18px;
   font-weight: bold;
 `;
@@ -92,7 +88,7 @@ export const Dot = styled.span`
 export const Footer = styled.div`
   text-align: center;
   margin-top: 12px;
-  font-size: 14px;
+  font-size: 22px;
   color: #555;
 `;
 export const Count = styled.span`

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -6,7 +6,11 @@ import HomeIcon from "@/assets/grayhome.svg";
 import CalendarIcon from "@/assets/dartkcalendar.svg";
 import MyPageIcon from "@/assets/mypage.svg";
 import GoToAnswer from "@/assets/goToAnswer.svg";
-import { useCreateMemoMutation, useMonthMemosQuery } from "@/api";
+import {
+  useCreateMemoMutation,
+  useMonthMemosQuery,
+  useMyGroupQuery,
+} from "@/api";
 import CalendarContainer from "@/components/CalendarContainer";
 
 const Calendar = () => {
@@ -14,14 +18,23 @@ const Calendar = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [content, setContent] = useState("");
   const createMemo = useCreateMemoMutation();
-  const { data: memos } = useMonthMemosQuery(1, "2025-06");
+  const { data: group } = useMyGroupQuery();
+  const groupId = group?.data.groupId || 0;
+  const startedAt = group?.data.startedAt;
+  const today = new Date();
+  const month = today.toISOString().slice(0, 7);
+  const todayDate = today.toISOString().slice(0, 10);
+  const dayNames = ["일", "월", "화", "수", "목", "금", "토"];
+  const todayLabel = `${today.getMonth() + 1}월 ${today.getDate()}일 ${dayNames[today.getDay()]}요일`;
+  const { data: memos } = useMonthMemosQuery(groupId, month);
 
   const GoHome = () => navigate("/home");
   const GoList = () => navigate("/list");
   const GoMyPage = () => navigate("/my-page");
   const ToggleModal = () => setModalOpen(!isModalOpen);
   const GoShowAnswer = () => {
-    createMemo.mutate({ groupId: 1, date: "2025-02-24", content });
+    if (!groupId) return;
+    createMemo.mutate({ groupId, date: todayDate, content });
     navigate("/show-answer");
   };
 
@@ -30,7 +43,10 @@ const Calendar = () => {
   return (
     <S.Layout>
       <p>캘린더</p>
-      <CalendarContainer />
+      <CalendarContainer
+        startDate={startedAt}
+        events={memos?.data.memos || []}
+      />
 
       <S.EditImg onClick={ToggleModal} style={{ cursor: "pointer" }} />
       <S.Footer>
@@ -45,7 +61,7 @@ const Calendar = () => {
       </S.Footer>
       <S.Modal isOpen={isModalOpen}>
         <S.TextContainer>
-          <h3>2월 16일 금요일</h3>
+          <h3>{todayLabel}</h3>
           <img
             src={GoToAnswer}
             style={{ cursor: "pointer" }}

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -31,14 +31,18 @@ const Calendar = () => {
   const GoHome = () => navigate("/home");
   const GoList = () => navigate("/list");
   const GoMyPage = () => navigate("/my-page");
-  const ToggleModal = () => setModalOpen(!isModalOpen);
+  const todayMemo = memos?.data.memos.find((m: any) => m.date === todayDate);
+  const ToggleModal = () => {
+    if (!isModalOpen) {
+      setContent(todayMemo?.content || "");
+    }
+    setModalOpen(!isModalOpen);
+  };
   const GoShowAnswer = () => {
     if (!groupId) return;
     createMemo.mutate({ groupId, date: todayDate, content });
     navigate("/show-answer");
   };
-
-  const firstMemo = memos?.data.memos[0];
 
   return (
     <S.Layout>
@@ -70,7 +74,7 @@ const Calendar = () => {
         </S.TextContainer>
         <S.Input
           placeholder="일정 내용을 입력하세요..."
-          value={content || firstMemo?.content || ""}
+          value={content}
           onChange={(e: any) => setContent(e.target.value)}
         />
       </S.Modal>

--- a/src/pages/ShowAnswer/index.tsx
+++ b/src/pages/ShowAnswer/index.tsx
@@ -5,6 +5,7 @@ import CloseSvg from "@/assets/close.svg";
 import ChatSvg from "@/assets/chat.svg";
 import { useNavigate } from "react-router-dom";
 import { useAnswersQuery } from "@/api";
+import { formatDateKorean } from "@/utils/format";
 
 const ShowAnswer = () => {
   const navigate = useNavigate();
@@ -32,7 +33,9 @@ const ShowAnswer = () => {
       <S.MainContainer>
         <S.QuestionNumberContainer>
           <span>질문 #1</span>
-          <span>{data?.data?.answers?.[0]?.createdAt ?? ""}</span>
+          <span>
+            {formatDateKorean(data?.data?.answers?.[0]?.createdAt ?? "")}
+          </span>
         </S.QuestionNumberContainer>
         <S.Question>{data?.data?.question}</S.Question>
         <S.MemberFeelContainer>
@@ -48,7 +51,9 @@ const ShowAnswer = () => {
             <S.Detial>
               <span>{ans.name}</span>
               {ans.createdAt && (
-                <span style={{ color: "#8A8A8A" }}>{ans.createdAt}</span>
+                <span style={{ color: "#8A8A8A" }}>
+                  {formatDateKorean(ans.createdAt)}
+                </span>
               )}
             </S.Detial>
             <S.AnswerText1>{ans.answer}</S.AnswerText1>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,11 @@
+export function formatDateKorean(dateStr: string): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr.replace(" ", "T"));
+  if (isNaN(date.getTime())) return dateStr;
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  });
+}


### PR DESCRIPTION
## Summary
- show navigation arrows correctly on calendar
- compute days since meeting using group start date
- default memo date to today

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1800d578832aaed60ab13585dcd7